### PR TITLE
Add monthly keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,22 @@
+---
+name: Keep Alive
+
+"on":
+  schedule:
+    # Run on the 1st of every month
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create empty keep-alive commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore: keep-alive commit"
+          git push


### PR DESCRIPTION
## Summary
- Adds a scheduled workflow that pushes an empty commit on the 1st of every month
- Prevents GitHub from disabling scheduled actions after 60 days of repo inactivity