### PR TITLE
feat: reusable release workflows (pr-title-lint + vscode) + shared commit types

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,63 @@
+name: PR Title Lint (reusable)
+
+# Reusable workflow: enforce Conventional Commits format on PR titles.
+#
+# We squash-on-merge, so the resulting main-branch commit IS the PR title —
+# which is what Release Please parses to bump versions and build changelogs.
+# The allowed types are single-sourced from conventional-commit-types.json in
+# this repo (the same list that feeds the release-please changelog sections),
+# so enforcement and changelog can never drift.
+#
+# Caller (in a consuming repo, .github/workflows/pr-title-lint.yml):
+#   name: PR Title Lint
+#   on:
+#     pull_request:
+#       types: [opened, edited, reopened, synchronize]
+#   jobs:
+#     lint:
+#       uses: meridianlabs-ai/actions/.github/workflows/pr-title-lint.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      require-scope:
+        description: "Require a scope, e.g. feat(api): ..."
+        type: boolean
+        default: false
+      types-ref:
+        description: "git ref of meridianlabs-ai/actions to read the shared type list from"
+        type: string
+        default: "v1"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch shared conventional-commit types
+        uses: actions/checkout@v4
+        with:
+          repository: meridianlabs-ai/actions
+          ref: ${{ inputs.types-ref }}
+          sparse-checkout: conventional-commit-types.json
+          sparse-checkout-cone-mode: false
+          path: _meridian_actions
+
+      - name: Extract allowed types
+        id: types
+        run: |
+          {
+            echo "types<<EOF"
+            jq -r '.[].type' _meridian_actions/conventional-commit-types.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Lint PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: ${{ steps.types.outputs.types }}
+          requireScope: ${{ inputs.require-scope }}

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -1,0 +1,156 @@
+name: Release Please — VS Code extension (reusable)
+
+# Reusable workflow: Release Please for a VS Code extension repo.
+#
+# On push to main, release-please maintains a rolling release PR (release-type
+# node — it owns the package.json version). Merging the PR creates the tag and
+# triggers the gated publish job, which packages the extension and publishes to
+# the VS Code Marketplace + Open VSX, and attaches the .vsix to the GitHub
+# release. Auth is a short-lived token from the Meridian release GitHub App.
+#
+# The consuming repo must provide these pnpm scripts: lint, build,
+# build:production, test, vsce:package. Add required reviewers to the
+# `environment` (default `marketplace`) to gate who can ship.
+#
+# Caller (in a consuming repo, .github/workflows/release.yml):
+#   name: Release
+#   on:
+#     push: { branches: [main] }
+#   jobs:
+#     release:
+#       uses: meridianlabs-ai/actions/.github/workflows/release-please-vscode.yml@v1
+#       with:
+#         extension-id: ukaisi.inspect-ai
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      extension-id:
+        description: "Marketplace extension id, e.g. ukaisi.inspect-ai"
+        type: string
+        required: true
+      node-version:
+        type: string
+        default: "22"
+      publish-openvsx:
+        description: "Also publish to Open VSX"
+        type: boolean
+        default: true
+      environment:
+        description: "Deployment environment for the publish job (add required reviewers to gate releases)"
+        type: string
+        default: "marketplace"
+      config-file:
+        type: string
+        default: ".release-please-config.json"
+      manifest-file:
+        type: string
+        default: ".release-please-manifest.json"
+    secrets:
+      RELEASE_PLEASE_APP_ID:
+        required: true
+      RELEASE_PLEASE_APP_PRIVATE_KEY:
+        required: true
+      VSCE_PAT:
+        required: true
+      OVSX_PAT:
+        required: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-type: node
+          config-file: ${{ inputs.config-file }}
+          manifest-file: ${{ inputs.manifest-file }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: TypeScript compile
+        run: pnpm build
+
+      - name: Build extension (production)
+        run: pnpm build:production
+
+      - name: Setup virtual display
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
+      - name: Run tests
+        run: xvfb-run -a pnpm test
+
+      - name: Package extension
+        run: pnpm vsce:package
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if npx @vscode/vsce show ${{ inputs.extension-id }} --json 2>/dev/null | grep -q "\"version\": \"${{ steps.version.outputs.version }}\""; then
+            echo "v${{ steps.version.outputs.version }} already on VS Code Marketplace, skipping"
+          else
+            pnpm vsce publish --no-dependencies --pat "$VSCE_PAT"
+          fi
+
+      - name: Publish to Open VSX
+        if: ${{ inputs.publish-openvsx }}
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          npm install -g ovsx
+          if ovsx get ${{ inputs.extension-id }} --metadata 2>/dev/null | grep -q "\"version\": \"${{ steps.version.outputs.version }}\""; then
+            echo "v${{ steps.version.outputs.version }} already on Open VSX, skipping"
+          else
+            ovsx publish *.vsix --pat "$OVSX_PAT"
+          fi
+
+      - name: Upload VSIX to GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} *.vsix --clobber

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # actions
 Global GitHub actions
 
+## Reusable release workflows
+
+Shared release automation for Meridian repos (see `Meridian/Release Process.md` in the ops vault for the full plan). Standardized on Release Please, authed by the "Meridian Release Bot" GitHub App (org secrets `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`). Pin callers to `@v1`.
+
+- **`.github/workflows/pr-title-lint.yml`** — enforce Conventional Commits on PR titles (we squash-merge, so the PR title becomes the commit). Allowed types are read from `conventional-commit-types.json`.
+- **`.github/workflows/release-please-vscode.yml`** — Release Please + publish for a VS Code extension (Marketplace + Open VSX + `.vsix` release asset).
+- **`.github/workflows/release-please-python.yml`** — _(coming next)_ Release Please + PyPI trusted-publishing for Python packages.
+- **`conventional-commit-types.json`** — single source of truth for commit types, feeding both PR-title lint and the release-please changelog sections.
+- **`scripts/gen-release-please-config.sh`** — generate a repo's committed `.release-please-config.json` from the shared type list.
+
+Minimal caller examples are in each workflow's header comment.
+
 ## Workflows
 
 ### Inspect AI Scheduled Tests

--- a/conventional-commit-types.json
+++ b/conventional-commit-types.json
@@ -1,0 +1,13 @@
+[
+  { "type": "feat", "section": "Features" },
+  { "type": "fix", "section": "Bug Fixes" },
+  { "type": "perf", "section": "Performance Improvements" },
+  { "type": "revert", "section": "Reverts" },
+  { "type": "refactor", "section": "Code Refactoring" },
+  { "type": "docs", "section": "Documentation" },
+  { "type": "chore", "section": "Miscellaneous" },
+  { "type": "build", "section": "Build System", "hidden": true },
+  { "type": "ci", "section": "Continuous Integration", "hidden": true },
+  { "type": "test", "section": "Tests", "hidden": true },
+  { "type": "style", "section": "Styles", "hidden": true }
+]

--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generate a repo's committed .release-please-config.json from the shared
+# conventional-commit-types.json, so the changelog type list stays
+# single-sourced. release-please-action reads its config from the repo (via the
+# API), so the config must be committed — run this at migration time and again
+# whenever the shared type list changes.
+#
+# Usage:
+#   gen-release-please-config.sh <release-type> <include-v-in-tag> [output]
+#     release-type      python | node
+#     include-v-in-tag  true | false   (false = bare tags like 0.3.2)
+#     output            defaults to .release-please-config.json
+#
+# Example:
+#   scripts/gen-release-please-config.sh python false > .release-please-config.json
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+types_file="$repo_root/conventional-commit-types.json"
+
+release_type="${1:?release-type required (python|node)}"
+include_v="${2:?include-v-in-tag required (true|false)}"
+out="${3:-}"
+
+config="$(jq \
+  --arg rt "$release_type" \
+  --argjson vtag "$include_v" \
+  '{
+    "release-type": $rt,
+    "include-v-in-tag": $vtag,
+    "packages": {
+      ".": {
+        "changelog-sections": .,
+        "release-notes-config": { "grouping": true }
+      }
+    }
+  }' "$types_file")"
+
+if [ -n "$out" ]; then
+  printf '%s\n' "$config" > "$out"
+  echo "wrote $out" >&2
+else
+  printf '%s\n' "$config"
+fi


### PR DESCRIPTION
First installment of the shared release automation (see `Meridian/Release Process.md` for the full plan). Establishes the pattern so each migrating repo needs only a **thin caller + committed manifest + CODEOWNERS**.

## What's here

| File | Purpose |
| --- | --- |
| `conventional-commit-types.json` | **Single source of truth** for commit types — feeds both PR-title lint and release-please changelog sections, so enforcement and changelog can't drift |
| `.github/workflows/pr-title-lint.yml` | Reusable: enforce Conventional Commits on PR titles (`amannn/action-semantic-pull-request`), reading the shared type list |
| `.github/workflows/release-please-vscode.yml` | Reusable: Release Please (`release-type: node`) + publish to VS Code Marketplace + Open VSX + `.vsix` release asset; App-token auth |
| `scripts/gen-release-please-config.sh` | Generate a repo's committed `.release-please-config.json` from the shared type list |

## Design notes

- **Auth = GitHub App**, not a personal PAT — the vscode workflow mints a token via `actions/create-github-app-token@v2` from org secrets `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`.
- **RP config must be committed per-repo** — `release-please-action` reads config from the repo via the API, *not* the runner filesystem, so we can't inject it at runtime. `gen-release-please-config.sh` keeps it single-sourced from the shared type list instead.
- **vscode gets a publish gate it lacks today** — the `environment` input (default `marketplace`) lets you add required reviewers, matching the `pypi`-environment gate the Python repos have.
- **Squash-merge assumed** — the PR title is the commit RP parses, so PR-title lint is the only enforcement needed (no commitlint/husky).

## ⚠️ Not runnable until (prerequisites, tracked in the vault plan)

- [x] "Meridian Release Bot" GitHub App created + org secrets added
- [ ] This merged and tagged **`v1`** (callers pin `@v1`; `pr-title-lint` reads the type list from `@v1` by default)
- [ ] Consuming repos add the thin caller + committed config (via the script) + manifest + CODEOWNERS

## Consuming-repo examples

Caller snippets are in each workflow's header comment. `release-please-vscode.yml` is intended for `inspect_vscode`; `pr-title-lint.yml` for every migrated repo.

## Next

`release-please-python.yml` (the workhorse for ~9 PyPI repos) is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)