### PR TITLE
docs: add permissions blocks to reusable-workflow caller examples

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -15,6 +15,8 @@ name: PR Title Lint (reusable)
 #       types: [opened, edited, reopened, synchronize]
 #   jobs:
 #     lint:
+#       permissions:
+#         pull-requests: read
 #       uses: meridianlabs-ai/actions/.github/workflows/pr-title-lint.yml@v1
 
 on:

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -18,6 +18,9 @@ name: Release Please — VS Code extension (reusable)
 #     push: { branches: [main] }
 #   jobs:
 #     release:
+#       permissions:
+#         contents: write
+#         pull-requests: write
 #       uses: meridianlabs-ai/actions/.github/workflows/release-please-vscode.yml@v1
 #       with:
 #         extension-id: ukaisi.inspect-ai


### PR DESCRIPTION
The caller examples in `pr-title-lint.yml` and `release-please-vscode.yml` omitted the `permissions:` blocks. Since a reusable workflow can't request more than the caller grants (and default `GITHUB_TOKEN` is often `pull-requests: none`), copying those examples verbatim produces "requesting X but only allowed none" errors (hit during the inspect_vscode migration). This adds the required permissions to both examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)