### PR TITLE
feat: bump release-please-action v4 -> v5

### DIFF
--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -73,7 +73,7 @@ jobs:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Migrates the reusable VS Code release workflow to `googleapis/release-please-action@v5`.

**Why:** v5 targets Node 24, clearing the runner warning "Node.js 20 is deprecated … forced to run on Node.js 24" for release-please-action. `release-type: node` behavior is unchanged, and `inspect_vscode` already ran on v5 before this migration, so it's low-risk.

**Note:** `actions/create-github-app-token` stays `@v2` — there's no newer major; its Node-20 warning self-resolves when upstream publishes a Node-24 build under v2 (we pin the moving major, so we pick it up automatically).

**After merge:** re-point `v1` to include this so callers pinned `@v1` (e.g. inspect_vscode) get it:
```
git tag -f -a v1 <merge-sha> -m "..." && git push -f origin v1
```

(When `release-please-python.yml` is built, it'll use v5 from the start.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)