### PR TITLE
feat: release-please-python reusable workflow + versioning arg

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -1,47 +1,45 @@
 name: Release Please — Python package (reusable)
 
-# Reusable workflow: Release Please for a Python package published to PyPI.
+# Reusable workflow: Release Please for a Python package (release-type python;
+# repos use hatch-vcs, so RP owns the changelog + creates the tag/GitHub
+# Release, and hatch-vcs derives the version from the tag at build time).
 #
-# On push to main, release-please maintains a rolling release PR (release-type
-# python; the repo uses hatch-vcs, so RP owns the changelog + creates the tag
-# and hatch-vcs derives the version from that tag at build time). Merging the
-# PR triggers the gated publish job, which builds and publishes to PyPI via
-# OIDC trusted publishing in the named environment. Auth for release-please is
-# a short-lived token from the Meridian release GitHub App.
+# IMPORTANT — this workflow does NOT publish. PyPI trusted publishing rejects
+# publishes that run from a cross-repo reusable workflow (it validates the
+# job_workflow_ref against a publisher registered in the package repo). So
+# publishing stays in the package repo's own publish.yaml, which is auto-run by
+# the GitHub Release that this workflow creates:
 #
-# The committed .release-please-config.json controls versioning and the
-# changelog sections (generate it from the shared type list with
-# scripts/gen-release-please-config.sh). The manifest holds the version state.
+#   # publish.yaml (in the package repo) — trusted publisher unchanged
+#   on:
+#     release:
+#       types: [published]      # auto-run when release-please cuts the release
+#     workflow_dispatch:        # keep for manual break-glass
+#       inputs: { confirm: { ... } }
+#   jobs:
+#     publish:
+#       if: ${{ github.event_name == 'release' || inputs.confirm == 'yes' }}
+#       environment: { name: pypi, url: https://pypi.org/p/<project> }
+#       ... build + pypa/gh-action-pypi-publish ...
 #
-# Caller (in a consuming repo, .github/workflows/release.yml):
+# The App token (not GITHUB_TOKEN) creates the Release, so it is allowed to
+# trigger publish.yaml.
+#
+# Caller (in the package repo, .github/workflows/release.yml):
 #   name: Release
 #   on:
 #     push: { branches: [main] }
 #   jobs:
-#     release:
+#     release-please:
 #       permissions:
 #         contents: write
 #         pull-requests: write
-#         id-token: write
 #       uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
-#       with:
-#         pypi-url: https://pypi.org/p/inspect-viz
 #       secrets: inherit
 
 on:
   workflow_call:
     inputs:
-      pypi-url:
-        description: "PyPI project URL for the deployment environment, e.g. https://pypi.org/p/inspect-viz"
-        type: string
-        required: true
-      environment:
-        description: "Deployment environment for the publish job (add required reviewers to gate releases)"
-        type: string
-        default: "pypi"
-      python-version:
-        type: string
-        default: "3.x"
       config-file:
         type: string
         default: ".release-please-config.json"
@@ -53,6 +51,13 @@ on:
         required: true
       RELEASE_PLEASE_APP_PRIVATE_KEY:
         required: true
+    outputs:
+      release_created:
+        description: "true when the release PR was merged and a release cut"
+        value: ${{ jobs.release-please.outputs.release_created }}
+      tag_name:
+        description: "tag of the created release, if any"
+        value: ${{ jobs.release-please.outputs.tag_name }}
 
 jobs:
   release-please:
@@ -77,36 +82,3 @@ jobs:
           release-type: python
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
-
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # Required for OIDC/PyPI trusted publishing
-    environment:
-      name: ${{ inputs.environment }}
-      url: ${{ inputs.pypi-url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0 # all tags — hatch-vcs derives the version from the tag
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ inputs.python-version }}
-
-      - name: Show current version
-        run: |
-          echo "Version: $(git describe --tags --always)"
-
-      - name: Build
-        run: |
-          pip install --upgrade pip build
-          python -m build
-          ls -la dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -1,0 +1,112 @@
+name: Release Please — Python package (reusable)
+
+# Reusable workflow: Release Please for a Python package published to PyPI.
+#
+# On push to main, release-please maintains a rolling release PR (release-type
+# python; the repo uses hatch-vcs, so RP owns the changelog + creates the tag
+# and hatch-vcs derives the version from that tag at build time). Merging the
+# PR triggers the gated publish job, which builds and publishes to PyPI via
+# OIDC trusted publishing in the named environment. Auth for release-please is
+# a short-lived token from the Meridian release GitHub App.
+#
+# The committed .release-please-config.json controls versioning and the
+# changelog sections (generate it from the shared type list with
+# scripts/gen-release-please-config.sh). The manifest holds the version state.
+#
+# Caller (in a consuming repo, .github/workflows/release.yml):
+#   name: Release
+#   on:
+#     push: { branches: [main] }
+#   jobs:
+#     release:
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#         id-token: write
+#       uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
+#       with:
+#         pypi-url: https://pypi.org/p/inspect-viz
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      pypi-url:
+        description: "PyPI project URL for the deployment environment, e.g. https://pypi.org/p/inspect-viz"
+        type: string
+        required: true
+      environment:
+        description: "Deployment environment for the publish job (add required reviewers to gate releases)"
+        type: string
+        default: "pypi"
+      python-version:
+        type: string
+        default: "3.x"
+      config-file:
+        type: string
+        default: ".release-please-config.json"
+      manifest-file:
+        type: string
+        default: ".release-please-manifest.json"
+    secrets:
+      RELEASE_PLEASE_APP_ID:
+        required: true
+      RELEASE_PLEASE_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v5
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-type: python
+          config-file: ${{ inputs.config-file }}
+          manifest-file: ${{ inputs.manifest-file }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC/PyPI trusted publishing
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.pypi-url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # all tags — hatch-vcs derives the version from the tag
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Show current version
+        run: |
+          echo "Version: $(git describe --tags --always)"
+
+      - name: Build
+        run: |
+          pip install --upgrade pip build
+          python -m build
+          ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared release automation for Meridian repos (see `Meridian/Release Process.md` 
 
 - **`.github/workflows/pr-title-lint.yml`** — enforce Conventional Commits on PR titles (we squash-merge, so the PR title becomes the commit). Allowed types are read from `conventional-commit-types.json`.
 - **`.github/workflows/release-please-vscode.yml`** — Release Please + publish for a VS Code extension (Marketplace + Open VSX + `.vsix` release asset).
-- **`.github/workflows/release-please-python.yml`** — _(coming next)_ Release Please + PyPI trusted-publishing for Python packages.
+- **`.github/workflows/release-please-python.yml`** — Release Please + PyPI trusted-publishing (OIDC) for Python packages (hatch-vcs).
 - **`conventional-commit-types.json`** — single source of truth for commit types, feeding both PR-title lint and the release-please changelog sections.
 - **`scripts/gen-release-please-config.sh`** — generate a repo's committed `.release-please-config.json` from the shared type list.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared release automation for Meridian repos (see `Meridian/Release Process.md` 
 
 - **`.github/workflows/pr-title-lint.yml`** — enforce Conventional Commits on PR titles (we squash-merge, so the PR title becomes the commit). Allowed types are read from `conventional-commit-types.json`.
 - **`.github/workflows/release-please-vscode.yml`** — Release Please + publish for a VS Code extension (Marketplace + Open VSX + `.vsix` release asset).
-- **`.github/workflows/release-please-python.yml`** — Release Please + PyPI trusted-publishing (OIDC) for Python packages (hatch-vcs).
+- **`.github/workflows/release-please-python.yml`** — Release Please for Python packages (release-please only; publishing stays in the repo's `publish.yaml`, auto-triggered by the GitHub Release — PyPI trusted publishing can't run from a cross-repo reusable workflow).
 - **`conventional-commit-types.json`** — single source of truth for commit types, feeding both PR-title lint and the release-please changelog sections.
 - **`scripts/gen-release-please-config.sh`** — generate a repo's committed `.release-please-config.json` from the shared type list.
 

--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -6,13 +6,14 @@
 # whenever the shared type list changes.
 #
 # Usage:
-#   gen-release-please-config.sh <release-type> <include-v-in-tag> [output]
+#   gen-release-please-config.sh <release-type> <include-v-in-tag> [versioning]
 #     release-type      python | node
-#     include-v-in-tag  true | false   (false = bare tags like 0.3.2)
-#     output            defaults to .release-please-config.json
+#     include-v-in-tag  true | false     (false = bare tags like 0.3.2)
+#     versioning        (optional) e.g. always-bump-patch. Omit for the
+#                       Conventional Commits default (feat->minor, fix->patch).
 #
-# Example:
-#   scripts/gen-release-please-config.sh python false > .release-please-config.json
+#   Output is written to stdout — redirect it, e.g.:
+#     scripts/gen-release-please-config.sh python false always-bump-patch > .release-please-config.json
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -20,25 +21,17 @@ types_file="$repo_root/conventional-commit-types.json"
 
 release_type="${1:?release-type required (python|node)}"
 include_v="${2:?include-v-in-tag required (true|false)}"
-out="${3:-}"
+versioning="${3:-}"
 
-config="$(jq \
+jq \
   --arg rt "$release_type" \
   --argjson vtag "$include_v" \
-  '{
-    "release-type": $rt,
-    "include-v-in-tag": $vtag,
-    "packages": {
-      ".": {
-        "changelog-sections": .,
-        "release-notes-config": { "grouping": true }
-      }
-    }
-  }' "$types_file")"
-
-if [ -n "$out" ]; then
-  printf '%s\n' "$config" > "$out"
-  echo "wrote $out" >&2
-else
-  printf '%s\n' "$config"
-fi
+  --arg ver "$versioning" \
+  '{ "release-type": $rt, "include-v-in-tag": $vtag }
+   + (if $ver != "" then { "versioning": $ver } else {} end)
+   + { "packages": {
+         ".": {
+           "changelog-sections": .,
+           "release-notes-config": { "grouping": true }
+         }
+       } }' "$types_file"


### PR DESCRIPTION
The workhorse reusable workflow for the ~9 PyPI repos, completing the shared-workflow set (`python`, `vscode`, `pr-title-lint`).

## What's here
- **`.github/workflows/release-please-python.yml`** — Release Please (`release-type: python`, hatch-vcs) + gated `publish` job that builds and ships to PyPI via **OIDC trusted publishing** in the named environment. App-token auth, `release-please-action@v5`.
- **`gen-release-please-config.sh`** — adds an optional **`versioning`** arg (e.g. `always-bump-patch`) and now writes to **stdout**. Lets each migration set its versioning policy from the shared type list; omit for the Conventional Commits default.

## Caller shape (~12 lines)
```yaml
jobs:
  release:
    permissions: { contents: write, pull-requests: write, id-token: write }
    uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
    with:
      pypi-url: https://pypi.org/p/inspect-viz
    secrets: inherit
```

## Notes
- Publish job needs `id-token: write` (OIDC), so callers grant all three permissions (union across the reusable workflow's jobs).
- `environment` (default `pypi`) carries the required-reviewer ship gate.
- Versioning per the decided policy: manual→RP migrations pass `always-bump-patch`; repos already on RP keep default semver.

## After merge
Re-point **`v1`** so callers pinned `@v1` pick this up (main has advanced past the current `v1` with #51/#52 anyway).