### PR TITLE
feat: Slack approval ping — dedicated channel, @-mention approvers

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -46,13 +46,17 @@ on:
       manifest-file:
         type: string
         default: ".release-please-manifest.json"
+      approvers:
+        description: "Space/comma-separated GitHub logins to @-mention in the Slack approval ping (resolved via slack-ids.json). Optional."
+        type: string
+        default: ""
     secrets:
       RELEASE_PLEASE_APP_ID:
         required: true
       RELEASE_PLEASE_APP_PRIVATE_KEY:
         required: true
-      SLACK_WEBHOOK_URL:
-        required: false # if set, posts a Slack ping when a release awaits publish approval
+      SLACK_APPROVALS_WEBHOOK_URL:
+        required: false # if set, posts a Slack ping to a dedicated approvals channel when a release awaits publish approval
     outputs:
       release_created:
         description: "true when the release PR was merged and a release cut"
@@ -85,22 +89,47 @@ jobs:
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
 
-      # Ping Slack when a release is cut, so the publish awaiting approval in the
-      # pypi environment is noticed (GitHub's own deployment-review notifications
-      # are unreliable — e.g. suppressed for the actor who triggered the run).
+      # Fetch the shared GitHub-login -> Slack-ID map so the approval ping can
+      # @-mention the right people. Only when a release was actually cut.
+      - name: Fetch Slack ID map
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: meridianlabs-ai/actions
+          ref: v1
+          sparse-checkout: slack-ids.json
+          sparse-checkout-cone-mode: false
+          path: _meridian_actions
+
+      # Ping the approvals channel when a release is cut, @-mentioning the
+      # approvers, so the publish awaiting approval in the pypi environment is
+      # noticed (GitHub's own deployment-review notifications are unreliable —
+      # e.g. suppressed for the actor who triggered the run). No-ops if the
+      # webhook secret is unset.
       - name: Notify Slack — release awaiting publish approval
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_APPROVALS_WEBHOOK_URL: ${{ secrets.SLACK_APPROVALS_WEBHOOK_URL }}
+          APPROVERS: ${{ inputs.approvers }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag_name }}
           ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions
         run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
+          if [ -z "$SLACK_APPROVALS_WEBHOOK_URL" ]; then
+            echo "SLACK_APPROVALS_WEBHOOK_URL not set — skipping Slack notification"
             exit 0
           fi
-          text=":rocket: *${REPO}* ${TAG} release created — PyPI publish is *awaiting approval*. Review: ${ACTIONS_URL}"
+          mentions=""
+          map=_meridian_actions/slack-ids.json
+          if [ -f "$map" ] && [ -n "$APPROVERS" ]; then
+            for login in $(echo "$APPROVERS" | tr ',' ' '); do
+              id=$(jq -r --arg l "$login" '.[$l] // empty' "$map")
+              if [ -n "$id" ] && [ "$id" != "TODO" ]; then
+                mentions="$mentions <@$id>"
+              fi
+            done
+          fi
+          text=":rocket: *${REPO}* ${TAG} release created — PyPI publish is *awaiting approval*.${mentions} Review: ${ACTIONS_URL}"
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "$(jq -n --arg t "$text" '{text: $t}')" \
-            "$SLACK_WEBHOOK_URL"
+            "$SLACK_APPROVALS_WEBHOOK_URL"

--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -51,6 +51,8 @@ on:
         required: true
       RELEASE_PLEASE_APP_PRIVATE_KEY:
         required: true
+      SLACK_WEBHOOK_URL:
+        required: false # if set, posts a Slack ping when a release awaits publish approval
     outputs:
       release_created:
         description: "true when the release PR was merged and a release cut"
@@ -82,3 +84,23 @@ jobs:
           release-type: python
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
+
+      # Ping Slack when a release is cut, so the publish awaiting approval in the
+      # pypi environment is noticed (GitHub's own deployment-review notifications
+      # are unreliable — e.g. suppressed for the actor who triggered the run).
+      - name: Notify Slack — release awaiting publish approval
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+          ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
+            exit 0
+          fi
+          text=":rocket: *${REPO}* ${TAG} release created — PyPI publish is *awaiting approval*. Review: ${ACTIONS_URL}"
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg t "$text" '{text: $t}')" \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -50,6 +50,10 @@ on:
       manifest-file:
         type: string
         default: ".release-please-manifest.json"
+      approvers:
+        description: "Space/comma-separated GitHub logins to @-mention in the Slack approval ping (resolved via slack-ids.json). Optional."
+        type: string
+        default: ""
     secrets:
       RELEASE_PLEASE_APP_ID:
         required: true
@@ -59,8 +63,8 @@ on:
         required: true
       OVSX_PAT:
         required: false
-      SLACK_WEBHOOK_URL:
-        required: false # if set, posts a Slack ping when a release awaits publish approval
+      SLACK_APPROVALS_WEBHOOK_URL:
+        required: false # if set, posts a Slack ping to a dedicated approvals channel when a release awaits publish approval
 
 jobs:
   release-please:
@@ -86,25 +90,49 @@ jobs:
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
 
-      # Ping Slack when a release is cut, so the publish awaiting approval in the
-      # environment is noticed (GitHub's own deployment-review notifications are
-      # unreliable — e.g. suppressed for the actor who triggered the run).
+      # Fetch the shared GitHub-login -> Slack-ID map so the approval ping can
+      # @-mention the right people.
+      - name: Fetch Slack ID map
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: meridianlabs-ai/actions
+          ref: v1
+          sparse-checkout: slack-ids.json
+          sparse-checkout-cone-mode: false
+          path: _meridian_actions
+
+      # Ping the approvals channel when a release is cut, @-mentioning the
+      # approvers, so the publish awaiting approval is noticed (GitHub's own
+      # deployment-review notifications are unreliable — e.g. suppressed for the
+      # actor who triggered the run). No-ops if the webhook secret is unset.
       - name: Notify Slack — release awaiting publish approval
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_APPROVALS_WEBHOOK_URL: ${{ secrets.SLACK_APPROVALS_WEBHOOK_URL }}
+          APPROVERS: ${{ inputs.approvers }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag_name }}
           ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions
         run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
+          if [ -z "$SLACK_APPROVALS_WEBHOOK_URL" ]; then
+            echo "SLACK_APPROVALS_WEBHOOK_URL not set — skipping Slack notification"
             exit 0
           fi
-          text=":rocket: *${REPO}* ${TAG} release created — Marketplace publish is *awaiting approval*. Review: ${ACTIONS_URL}"
+          mentions=""
+          map=_meridian_actions/slack-ids.json
+          if [ -f "$map" ] && [ -n "$APPROVERS" ]; then
+            for login in $(echo "$APPROVERS" | tr ',' ' '); do
+              id=$(jq -r --arg l "$login" '.[$l] // empty' "$map")
+              if [ -n "$id" ] && [ "$id" != "TODO" ]; then
+                mentions="$mentions <@$id>"
+              fi
+            done
+          fi
+          text=":rocket: *${REPO}* ${TAG} release created — Marketplace publish is *awaiting approval*.${mentions} Review: ${ACTIONS_URL}"
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "$(jq -n --arg t "$text" '{text: $t}')" \
-            "$SLACK_WEBHOOK_URL"
+            "$SLACK_APPROVALS_WEBHOOK_URL"
 
   publish:
     needs: release-please

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -59,6 +59,8 @@ on:
         required: true
       OVSX_PAT:
         required: false
+      SLACK_WEBHOOK_URL:
+        required: false # if set, posts a Slack ping when a release awaits publish approval
 
 jobs:
   release-please:
@@ -83,6 +85,26 @@ jobs:
           release-type: node
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
+
+      # Ping Slack when a release is cut, so the publish awaiting approval in the
+      # environment is noticed (GitHub's own deployment-review notifications are
+      # unreliable — e.g. suppressed for the actor who triggered the run).
+      - name: Notify Slack — release awaiting publish approval
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+          ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set — skipping Slack notification"
+            exit 0
+          fi
+          text=":rocket: *${REPO}* ${TAG} release created — Marketplace publish is *awaiting approval*. Review: ${ACTIONS_URL}"
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg t "$text" '{text: $t}')" \
+            "$SLACK_WEBHOOK_URL"
 
   publish:
     needs: release-please

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Shared release automation for Meridian repos (see `Meridian/Release Process.md` 
 - **`conventional-commit-types.json`** — single source of truth for commit types, feeding both PR-title lint and the release-please changelog sections.
 - **`scripts/gen-release-please-config.sh`** — generate a repo's committed `.release-please-config.json` from the shared type list.
 
-Both release-please workflows post a **Slack "awaiting approval"** ping when a release is cut, if an org (or repo) secret `SLACK_WEBHOOK_URL` is set — GitHub's own deployment-review notifications are unreliable. The ping fires from the release-please job (before the environment gate), links to the repo's Actions, and no-ops silently if the secret is absent.
+Both release-please workflows post a **Slack "awaiting approval"** ping when a release is cut, if the secret `SLACK_APPROVALS_WEBHOOK_URL` is set (a **dedicated approvals channel** webhook, separate from any general update stream). GitHub's own deployment-review notifications are unreliable, so this ensures approvers hear about it. The ping fires from the release-please job (before the environment gate), links to the repo's Actions, no-ops silently if the secret is absent, and **@-mentions the approvers** passed via the `approvers` input (space/comma-separated GitHub logins), resolved to Slack IDs through **`slack-ids.json`** (login → Slack member ID; fill in the `TODO`s). Since the Slack app is incoming-webhook only (no bot token), mentions in the approvals channel are used rather than true DMs.
 
 Minimal caller examples are in each workflow's header comment.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Shared release automation for Meridian repos (see `Meridian/Release Process.md` 
 - **`conventional-commit-types.json`** — single source of truth for commit types, feeding both PR-title lint and the release-please changelog sections.
 - **`scripts/gen-release-please-config.sh`** — generate a repo's committed `.release-please-config.json` from the shared type list.
 
+Both release-please workflows post a **Slack "awaiting approval"** ping when a release is cut, if an org (or repo) secret `SLACK_WEBHOOK_URL` is set — GitHub's own deployment-review notifications are unreliable. The ping fires from the release-please job (before the environment gate), links to the repo's Actions, and no-ops silently if the secret is absent.
+
 Minimal caller examples are in each workflow's header comment.
 
 ## Workflows

--- a/slack-ids.json
+++ b/slack-ids.json
@@ -1,10 +1,10 @@
 {
   "_comment": "GitHub login -> Slack member ID (e.g. U012ABC). Used by the release-please reusable workflows to @-mention release approvers in the approvals channel. Find an ID in Slack: profile -> ... -> Copy member ID. Entries left as TODO are skipped (no mention).",
-  "dragonstyle": "TODO",
-  "jjallaire": "TODO",
-  "epatey": "TODO",
-  "alexandraabbas": "TODO",
-  "kaifronsdal": "TODO",
-  "ransomr": "TODO",
-  "brandly": "TODO"
+  "dragonstyle": "U08L7H4NBQT",
+  "jjallaire": "U07V6G0G0GN",
+  "epatey": "U0862T8T1CH",
+  "alexandraabbas": "U0806EY36KY",
+  "kaifronsdal": "U09SD50BTLY",
+  "ransomr": "U09FQSMKKPC",
+  "brandly": "U095EA33KUZ"
 }

--- a/slack-ids.json
+++ b/slack-ids.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "GitHub login -> Slack member ID (e.g. U012ABC). Used by the release-please reusable workflows to @-mention release approvers in the approvals channel. Find an ID in Slack: profile -> ... -> Copy member ID. Entries left as TODO are skipped (no mention).",
+  "dragonstyle": "TODO",
+  "jjallaire": "TODO",
+  "epatey": "TODO",
+  "alexandraabbas": "TODO",
+  "kaifronsdal": "TODO",
+  "ransomr": "TODO",
+  "brandly": "TODO"
+}


### PR DESCRIPTION
Adds a Slack notification when a release awaits publish approval, because GitHub's deployment-review notifications are unreliable (notably suppressed for the actor who triggered the run).

## Approach (given the app is incoming-webhook only)
`meridian-slack-notifications` has only the `incoming-webhook` scope — no bot token — so it **can't DM**. Instead we post to a **dedicated approvals channel** and **@-mention** the approvers, which pings them personally.

- **`SLACK_APPROVALS_WEBHOOK_URL`** (optional secret) → the approvals channel, separate from any general `SLACK_WEBHOOK_URL` update stream.
- **`approvers`** input (space/comma-separated GitHub logins) → resolved to Slack member IDs via a shared **`slack-ids.json`** (login → `U…`), and `@`-mentioned. Unmapped / `TODO` entries are skipped.
- Fires from the **release-please job** (before the environment gate — a step in the gated publish job wouldn't run until after approval). No-ops if the webhook secret is unset.

## Your setup
- [x] Create a `#release-approvals` channel + an incoming webhook for it (via `meridian-slack-notifications`); store the URL as org secret **`SLACK_APPROVALS_WEBHOOK_URL`**.
- [x] Fill in **`slack-ids.json`** — the `TODO`s → each approver's Slack member ID (Slack profile → ⋯ → Copy member ID).
- Callers pass e.g. `with: { approvers: "dragonstyle jjallaire epatey" }`.

## After merge
Re-point `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)