### PR TITLE
fix: versioning modes (default | patch-pre-major), drop always-bump-patch + include-v-in-tag

### DIFF
--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -6,28 +6,30 @@
 # whenever the shared type list changes.
 #
 # Usage:
-#   gen-release-please-config.sh <release-type> <include-v-in-tag> [versioning]
-#     release-type      python | node
-#     include-v-in-tag  true | false     (false = bare tags like 0.3.2)
-#     versioning        (optional) e.g. always-bump-patch. Omit for the
-#                       Conventional Commits default (feat->minor, fix->patch).
+#   gen-release-please-config.sh <release-type> [versioning]
+#     release-type   python | node
+#     versioning     (optional) e.g. always-bump-patch. Omit for the
+#                    Conventional Commits default (feat->minor, fix->patch).
 #
 #   Output is written to stdout — redirect it, e.g.:
-#     scripts/gen-release-please-config.sh python false always-bump-patch > .release-please-config.json
+#     scripts/gen-release-please-config.sh python always-bump-patch > .release-please-config.json
+#
+# Tags are v-prefixed (release-please default). We do NOT set include-v-in-tag:
+# version state lives in .release-please-manifest.json (not tags), and hatch-vcs
+# strips the leading v, so the tag prefix is cosmetic. (In manifest mode a
+# top-level include-v-in-tag is ignored anyway.)
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 types_file="$repo_root/conventional-commit-types.json"
 
 release_type="${1:?release-type required (python|node)}"
-include_v="${2:?include-v-in-tag required (true|false)}"
-versioning="${3:-}"
+versioning="${2:-}"
 
 jq \
   --arg rt "$release_type" \
-  --argjson vtag "$include_v" \
   --arg ver "$versioning" \
-  '{ "release-type": $rt, "include-v-in-tag": $vtag }
+  '{ "release-type": $rt }
    + (if $ver != "" then { "versioning": $ver } else {} end)
    + { "packages": {
          ".": {

--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -6,34 +6,45 @@
 # whenever the shared type list changes.
 #
 # Usage:
-#   gen-release-please-config.sh <release-type> [versioning]
-#     release-type   python | node
-#     versioning     (optional) e.g. always-bump-patch. Omit for the
-#                    Conventional Commits default (feat->minor, fix->patch).
+#   gen-release-please-config.sh <release-type> [versioning-mode]
+#     release-type      python | node
+#     versioning-mode   (optional):
+#       default          Conventional Commits default: feat->minor, fix->patch,
+#                        chore/docs/etc -> no release. (Also used when omitted.)
+#       patch-pre-major  feat->patch, fix->patch, breaking (feat!:)->minor,
+#                        chore/docs -> no release. Pre-1.0 only (reverts to
+#                        feat->minor once the repo hits 1.0). Use for repos that
+#                        want "feat = patch, minors rare/deliberate".
 #
 #   Output is written to stdout — redirect it, e.g.:
-#     scripts/gen-release-please-config.sh python always-bump-patch > .release-please-config.json
+#     scripts/gen-release-please-config.sh python patch-pre-major > .release-please-config.json
 #
-# Tags are v-prefixed (release-please default). We do NOT set include-v-in-tag:
-# version state lives in .release-please-manifest.json (not tags), and hatch-vcs
-# strips the leading v, so the tag prefix is cosmetic. (In manifest mode a
-# top-level include-v-in-tag is ignored anyway.)
+# Notes:
+# - Tags are v-prefixed (release-please default); version state lives in the
+#   manifest, not tags, and hatch-vcs strips the leading v, so the prefix is
+#   cosmetic. We do NOT set include-v-in-tag.
+# - Do NOT use always-bump-patch: it releases on EVERY commit (chore/docs/CI),
+#   producing no-op releases. It's meant only for backport branches.
+# - Versioning keys are placed per-package (top-level tag/versioning options can
+#   be ignored in manifest mode — learned from include-v-in-tag).
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 types_file="$repo_root/conventional-commit-types.json"
 
 release_type="${1:?release-type required (python|node)}"
-versioning="${2:-}"
+mode="${2:-default}"
+
+case "$mode" in
+  default) extra='{}' ;;
+  patch-pre-major) extra='{"bump-minor-pre-major": true, "bump-patch-for-minor-pre-major": true}' ;;
+  *) echo "unknown versioning-mode: $mode (use: default | patch-pre-major)" >&2; exit 2 ;;
+esac
 
 jq \
   --arg rt "$release_type" \
-  --arg ver "$versioning" \
-  '{ "release-type": $rt }
-   + (if $ver != "" then { "versioning": $ver } else {} end)
-   + { "packages": {
-         ".": {
-           "changelog-sections": .,
-           "release-notes-config": { "grouping": true }
-         }
-       } }' "$types_file"
+  --argjson extra "$extra" \
+  '{ "release-type": $rt,
+     "packages": {
+       ".": ( { "changelog-sections": ., "release-notes-config": { "grouping": true } } + $extra )
+     } }' "$types_file"


### PR DESCRIPTION
Two generator fixes learned from the inspect_viz pilot:

**1. `always-bump-patch` releases on every commit — dropped.** It overrides release-please's normal feat/fix-only triggering and cuts a patch release for *any* commit (chore/docs/CI). Observed live: `inspect_viz 0.4.1` was cut from a chore + a docs commit with **zero `src/` changes** — a no-op release. release-please's docs say always-bump-patch is only for backport branches.

**2. `include-v-in-tag` at top level is ignored in manifest mode — dropped.** (Got `v0.4.1` despite `false`.) Tags are v-prefixed everywhere; the manifest holds version state and hatch-vcs strips the `v`, so it's cosmetic.

## New generator interface
`gen-release-please-config.sh <release-type> [versioning-mode]`
- **`default`** (or omit) — standard semver: `feat`→minor, `fix`→patch, chore/docs → no release. For repos that want stock RP behavior.
- **`patch-pre-major`** — `feat`→patch, `fix`→patch, breaking→minor (pre-1.0); chore/docs → no release. The 'feat = patch, no empty bumps' behavior.

Versioning keys are placed **per-package** (top-level can be ignored in manifest mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)