### PR TITLE
feat: expose html_url + body outputs for release announcements

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -64,6 +64,12 @@ on:
       tag_name:
         description: "tag of the created release, if any"
         value: ${{ jobs.release-please.outputs.tag_name }}
+      html_url:
+        description: "URL of the created GitHub Release (for announcements)"
+        value: ${{ jobs.release-please.outputs.html_url }}
+      body:
+        description: "release notes body of the created release (for announcements)"
+        value: ${{ jobs.release-please.outputs.body }}
 
 jobs:
   release-please:
@@ -73,6 +79,8 @@ jobs:
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      html_url: ${{ steps.release.outputs.html_url }}
+      body: ${{ steps.release.outputs.body }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
Adds `html_url` and `body` (release notes) as workflow outputs on `release-please-python.yml`, so a caller can post a **release announcement** using the reusable workflow. Needed for the `inspect_flow` retrofit — flow has a rich `notify-slack` announcement job that consumes these. Backward compatible (existing callers ignore them).

After merge: re-point `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)