### PR TITLE
feat: generator tag-format option (preserve bare tag schemes)

### DIFF
--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -6,27 +6,26 @@
 # whenever the shared type list changes.
 #
 # Usage:
-#   gen-release-please-config.sh <release-type> [versioning-mode]
+#   gen-release-please-config.sh <release-type> [versioning-mode] [tag-format]
 #     release-type      python | node
-#     versioning-mode   (optional):
+#     versioning-mode   (optional; default `default`):
 #       default          Conventional Commits default: feat->minor, fix->patch,
-#                        chore/docs/etc -> no release. (Also used when omitted.)
+#                        chore/docs/etc -> no release.
 #       patch-pre-major  feat->patch, fix->patch, breaking (feat!:)->minor,
-#                        chore/docs -> no release. Pre-1.0 only (reverts to
-#                        feat->minor once the repo hits 1.0). Use for repos that
-#                        want "feat = patch, minors rare/deliberate".
+#                        chore/docs -> no release. Pre-1.0 only.
+#     tag-format        (optional; default `v`):
+#       v                v-prefixed tags (release-please default), e.g. v1.2.3
+#       bare             bare tags, e.g. 1.2.3 (preserve a repo's existing bare
+#                        scheme). Emits include-v-in-tag: false PER-PACKAGE
+#                        (top-level is ignored in manifest mode).
 #
 #   Output is written to stdout — redirect it, e.g.:
-#     scripts/gen-release-please-config.sh python patch-pre-major > .release-please-config.json
+#     scripts/gen-release-please-config.sh python patch-pre-major bare > .release-please-config.json
 #
 # Notes:
-# - Tags are v-prefixed (release-please default); version state lives in the
-#   manifest, not tags, and hatch-vcs strips the leading v, so the prefix is
-#   cosmetic. We do NOT set include-v-in-tag.
-# - Do NOT use always-bump-patch: it releases on EVERY commit (chore/docs/CI),
-#   producing no-op releases. It's meant only for backport branches.
-# - Versioning keys are placed per-package (top-level tag/versioning options can
-#   be ignored in manifest mode — learned from include-v-in-tag).
+# - Version state lives in the manifest, not tags; hatch-vcs strips the leading
+#   v — so tag-format is cosmetic, but we preserve each repo's existing scheme.
+# - Do NOT use always-bump-patch: it releases on EVERY commit (chore/docs/CI).
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -34,17 +33,25 @@ types_file="$repo_root/conventional-commit-types.json"
 
 release_type="${1:?release-type required (python|node)}"
 mode="${2:-default}"
+tagfmt="${3:-v}"
 
 case "$mode" in
-  default) extra='{}' ;;
-  patch-pre-major) extra='{"bump-minor-pre-major": true, "bump-patch-for-minor-pre-major": true}' ;;
+  default) ver_extra='{}' ;;
+  patch-pre-major) ver_extra='{"bump-minor-pre-major": true, "bump-patch-for-minor-pre-major": true}' ;;
   *) echo "unknown versioning-mode: $mode (use: default | patch-pre-major)" >&2; exit 2 ;;
+esac
+
+case "$tagfmt" in
+  v) tag_extra='{}' ;;
+  bare) tag_extra='{"include-v-in-tag": false}' ;;
+  *) echo "unknown tag-format: $tagfmt (use: v | bare)" >&2; exit 2 ;;
 esac
 
 jq \
   --arg rt "$release_type" \
-  --argjson extra "$extra" \
+  --argjson ver "$ver_extra" \
+  --argjson tag "$tag_extra" \
   '{ "release-type": $rt,
      "packages": {
-       ".": ( { "changelog-sections": ., "release-notes-config": { "grouping": true } } + $extra )
+       ".": ( { "changelog-sections": ., "release-notes-config": { "grouping": true } } + $ver + $tag )
      } }' "$types_file"


### PR DESCRIPTION
Adds a `tag-format` arg to the config generator so repos **keep their existing tag scheme** (per the 'don't change tag formats' preference).

- `v` (default) — v-prefixed tags (release-please default)
- `bare` — emits `include-v-in-tag: false` **per-package** (top-level is ignored in manifest mode — the lesson from inspect_viz getting `v0.4.1` despite the flag)

Usage: `gen-release-please-config.sh <release-type> [versioning-mode] [tag-format]`.

The bare 0.x manual-migration repos (`swe`, `scout`, `petri_dish`, `petri_bloom`, and `viz` going forward) use `python patch-pre-major bare`. **Per-package placement will be verified on the first bare release** (viz 0.4.2 should come out bare, not v0.4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)