### PR TITLE
feat: add target-branch input for hotfix/maintenance releases

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -43,6 +43,10 @@ on:
         description: "Post the approval ping from this workflow (deep-links to github.run_id). Set false if publish is a separate run and you ping from there instead."
         type: boolean
         default: true
+      target-branch:
+        description: "Branch Release Please manages. Leave empty for the default branch (normal releases); set to a maintenance branch (e.g. hotfix/1.4.x) to cut a hotfix release from a released tag."
+        type: string
+        default: ""
     secrets:
       RELEASE_PLEASE_APP_ID:
         required: true
@@ -89,6 +93,8 @@ jobs:
           release-type: python
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
+          # Empty string → the action falls back to the repo default branch.
+          target-branch: ${{ inputs.target-branch }}
 
       # Approval ping (retrofit style: publish runs in this same run, so
       # github.run_id is the run that will pause on the pypi environment).

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -54,6 +54,10 @@ on:
         description: "Space/comma-separated GitHub logins to @-mention in the Slack approval ping (resolved via slack-ids.json). Optional."
         type: string
         default: ""
+      target-branch:
+        description: "Branch Release Please manages. Leave empty for the default branch (normal releases); set to a maintenance branch (e.g. hotfix/1.4.x) to cut a hotfix release from a released tag."
+        type: string
+        default: ""
     secrets:
       RELEASE_PLEASE_APP_ID:
         required: true
@@ -89,6 +93,8 @@ jobs:
           release-type: node
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
+          # Empty string → the action falls back to the repo default branch.
+          target-branch: ${{ inputs.target-branch }}
 
       # Fetch the shared GitHub-login -> Slack-ID map so the approval ping can
       # @-mention the right people.


### PR DESCRIPTION
## What

Adds an optional `target-branch` input to both reusable release workflows (`release-please-python.yml`, `release-please-vscode.yml`) and passes it to `googleapis/release-please-action@v5`.

- Default is `""` → the action falls back to the repo default branch, so **normal releases are unchanged** (fully backward-compatible).
- Set it to a maintenance branch (e.g. `hotfix/1.4.x`) to have Release Please compute a release from *that* branch instead of `main`.

## Why

Release Please releases from the tip of the branch it manages. Hotfixing off `main` would ship everything queued there. The idiomatic fix is a maintenance branch rooted on the last released tag; this input is what lets a caller point Release Please at it.

## Rollout order (important)

This is the enabling half. Callers can't pass `target-branch` until this is merged and `v1` is re-tagged. **Merge this + move `v1` first**, then add the `workflow_dispatch` trigger + pass-through to the per-repo `release.yaml` callers. Merging a caller change first would break its normal release run (unknown input on old `v1`).