### PR TITLE
fix: drop release-type input so manifest config is actually honored

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -90,7 +90,10 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: python
+          # No release-type here: in manifest mode it must come from the
+          # config-file. Setting it as an input puts the action in simple mode
+          # and silently overrides the config's per-package options (versioning
+          # strategy, include-v-in-tag, changelog-sections).
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
           # Empty string → the action falls back to the repo default branch.

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -90,7 +90,10 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: node
+          # No release-type here: in manifest mode it must come from the
+          # config-file. Setting it as an input puts the action in simple mode
+          # and silently overrides the config's per-package options (versioning
+          # strategy, include-v-in-tag, changelog-sections).
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
           # Empty string → the action falls back to the repo default branch.


### PR DESCRIPTION
## The real root cause

Both reusable workflows passed `release-type` **as a direct input** to `release-please-action@v5` *alongside* `config-file`/`manifest-file`. Per the [action's docs](https://github.com/googleapis/release-please-action): **"do not set `release-type` when using manifest configuration."** Setting it runs the action in simple mode and **silently overrides the config file's per-package options** with defaults.

That's what caused every symptom we chased on scout:
- `feat` → **minor** (`0.5.0`) instead of patch (`0.4.45`) — `bump-patch-for-minor-pre-major` ignored
- **`v`-prefixed** tags despite `include-v-in-tag: false`
- **docs** leaking into notes despite the hidden flag

(The earlier `release-notes-config` removal in #64 was valid cleanup but not the cause — removing it alone didn't fix the regen, which is how we found this.)

## Fix

Remove the `release-type` input from both reusable workflows. `release-type` now comes from each repo's `config-file` (top-level `"release-type"`), which every consumer already sets (verified: scout=python, vscode=node, flow=python).

## Rollout (this one needs a v1 re-tag)

Unlike the generator/config fixes, this is in the **reusable workflow**, so:
1. Merge this.
2. **Re-tag `v1`** (`git tag -f v1 && git push -f origin v1`) so callers pick it up.
3. Reopen scout's release PR → verify it computes **0.4.45 (bare)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)