### PR TITLE
feat: single-control hotfix (derive target-branch from dispatched ref) + runbook

### DIFF
--- a/.github/workflows/release-please-python.yml
+++ b/.github/workflows/release-please-python.yml
@@ -96,8 +96,13 @@ jobs:
           # strategy, include-v-in-tag, changelog-sections).
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
-          # Empty string → the action falls back to the repo default branch.
-          target-branch: ${{ inputs.target-branch }}
+          # Default to the branch the run was triggered from (github.ref_name):
+          # push to main → main; a workflow_dispatch from a maintenance branch →
+          # that branch. This keeps the Release Please target and the publish
+          # checkout on the SAME branch, so a hotfix is driven solely by the
+          # "Use workflow from" branch selector — no separate input to mismatch.
+          # The target-branch input remains an optional explicit override.
+          target-branch: ${{ inputs.target-branch != '' && inputs.target-branch || github.ref_name }}
 
       # Approval ping (retrofit style: publish runs in this same run, so
       # github.run_id is the run that will pause on the pypi environment).

--- a/.github/workflows/release-please-vscode.yml
+++ b/.github/workflows/release-please-vscode.yml
@@ -96,8 +96,13 @@ jobs:
           # strategy, include-v-in-tag, changelog-sections).
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}
-          # Empty string → the action falls back to the repo default branch.
-          target-branch: ${{ inputs.target-branch }}
+          # Default to the branch the run was triggered from (github.ref_name):
+          # push to main → main; a workflow_dispatch from a maintenance branch →
+          # that branch. This keeps the Release Please target and the publish
+          # checkout on the SAME branch, so a hotfix is driven solely by the
+          # "Use workflow from" branch selector — no separate input to mismatch.
+          # The target-branch input remains an optional explicit override.
+          target-branch: ${{ inputs.target-branch != '' && inputs.target-branch || github.ref_name }}
 
       # Fetch the shared GitHub-login -> Slack-ID map so the approval ping can
       # @-mention the right people.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,19 +106,21 @@ are excluded.
 
 ## Hotfix / maintenance-branch releases
 
+> ⚠️ **Not yet exercised on a real hotfix.** The wiring is in place but unproven
+> end-to-end — validate the steps below (especially the dispatch ref and the
+> post-merge trigger) the first time you use it, and correct this section with
+> what you learn.
+
 When `main` has unreleased work but one fix must ship now, you can't release off
 `main` (that would drag everything queued there). Use a maintenance branch
 rooted at the last released tag. Example: last shipped `1.4.0`, need `1.4.1`:
 
-1. **Branch from the tag, not `main`:** `git checkout -b hotfix/1.4.x 1.4.0 && git push -u origin hotfix/1.4.x`
-2. **Cherry-pick the fix** as a `fix:` commit and push it.
-3. **Run Release Please against that branch:** repo → **Actions → Release → Run
-   workflow**, leave the ref on `main` (that's just where the workflow file is
-   read from) and set the **`target-branch`** input to `hotfix/1.4.x`. It opens
-   a release PR proposing `1.4.1` computed only from that branch.
-4. **Merge it** → tag `1.4.1` → approve the publish.
-5. **Forward-port the fix to `main`** — Release Please will *not* do this for
-   you; skip it and the next regular release regresses the bug.
+1. **Branch from the tag, not `main`:** `git checkout -b hotfix/1.4.x 1.4.0 && git push -u origin hotfix/1.4.x`. The branch must contain `.github/workflows/release.yml` with the `workflow_dispatch` trigger — a tag cut *before* that trigger existed needs it **cherry-picked onto the maintenance branch first**.
+2. **Cherry-pick the fix** as a `fix:` commit and push it to the maintenance branch.
+3. **Run Release Please from that branch:** repo → **Actions → Release → Run workflow**, and set **"Use workflow from" to the maintenance branch** (`hotfix/1.4.x`). That's the only control — Release Please targets the branch you dispatch from, and the publish checks out the same branch, so they can't diverge. It opens a release PR proposing `1.4.1` from that branch.
+4. **Merge the release PR** (into the maintenance branch) → tags `1.4.1`. Note: merging into a `hotfix/**` branch is *not* a push to `main`, so it won't auto-trigger Release Please to cut the GitHub Release — **re-run the dispatch** (again from the maintenance branch) after merging so RP creates the release, which fires the publish.
+5. **Approve the publish.**
+6. **Forward-port the fix to `main`** — Release Please will *not* do this for you; skip it and the next regular release regresses the bug.
 
 If nothing else is unreleased on `main`, skip all this — just let the normal
 `main` release flow ship the fix.


### PR DESCRIPTION
## What

Derive `target-branch` from the branch the run is triggered from:
```yaml
target-branch: ${{ inputs.target-branch != '' && inputs.target-branch || github.ref_name }}
```
in both reusable workflows, and simplify the `RELEASING.md` hotfix section to match.

## Why

Manually running a hotfix previously required setting **two** things consistently — the **"Use workflow from"** branch dropdown (which sets `github.ref`, used by the publish checkout) *and* the `target-branch` input (which Release Please releases from). Mismatching them tags the hotfix but publishes `main`'s code (flagged in inspect_vscode#143 review).

Now the **branch selector is the single control**: dispatch from the maintenance branch and Release Please targets it *and* the publish checks it out — they can't diverge. `target-branch` remains an optional explicit override (default empty).

- **Normal releases unchanged:** push to `main` → `github.ref_name` = `main`.
- **Backward compatible:** callers still passing `target-branch` keep working; this only changes the default when it's empty.

## Rollout

1. Merge this → **re-tag `v1`**.
2. Follow-up: drop the now-redundant `target-branch` `workflow_dispatch` input + pass-through from the per-repo callers (small fan-out), so the dispatch UI shows just the branch selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)