### PR TITLE
fix: emit include-component-in-tag: false (plain tags in manifest mode)

### DIFF
--- a/scripts/gen-release-please-config.sh
+++ b/scripts/gen-release-please-config.sh
@@ -47,11 +47,15 @@ case "$tagfmt" in
   *) echo "unknown tag-format: $tagfmt (use: v | bare)" >&2; exit 2 ;;
 esac
 
+# include-component-in-tag: false — in manifest mode the node strategy defaults
+# to component-prefixed tags (<package-name>-v1.2.3), which breaks the anchor
+# against our plain-v (or bare) tag history. Python doesn't prefix, so this is a
+# no-op there; emitted always for uniformity.
 jq \
   --arg rt "$release_type" \
   --argjson ver "$ver_extra" \
   --argjson tag "$tag_extra" \
   '{ "release-type": $rt,
      "packages": {
-       ".": ( { "changelog-sections": . } + $ver + $tag )
+       ".": ( { "include-component-in-tag": false, "changelog-sections": . } + $ver + $tag )
      } }' "$types_file"


### PR DESCRIPTION
Follow-up to #65. In manifest mode the **node** strategy defaults to component-prefixed tags (`<package-name>-v1.2.3`). After #65 moved everything to manifest mode, vscode's release PR lost its anchor (no `inspect-ai-v*` tags exist — history is plain `v0.9.x`) and proposed a bogus `0.3.65` with a full-history changelog (inspect_vscode#138).

Emit `include-component-in-tag: false` in generated configs so tags stay plain `v{version}` (or bare). No-op for python — its strategy doesn't prefix components — emitted always for uniformity.

vscode's committed config is patched directly in inspect_vscode#145; this makes the generator produce the same going forward. No `v1` re-tag needed (generator is run by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)