### PR TITLE
fix: pass MARVIN_TOKEN as claude-code-action github_token

### DIFF
--- a/.github/workflows/triage-test-failures.yml
+++ b/.github/workflows/triage-test-failures.yml
@@ -24,7 +24,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      id-token: write
 
     env:
       # Tracking issues are created in the meridianlabs-ai fork of inspect_ai,
@@ -105,6 +104,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The action replaces GH_TOKEN/GITHUB_TOKEN in Claude's environment
+          # with its own app installation token, which is read-only on
+          # $ISSUES_REPO ("Resource not accessible by integration" on issue
+          # comments). Passing MARVIN_TOKEN here skips that token exchange so
+          # gh inside the agent authenticates as marvin, which has write
+          # access on $ISSUES_REPO.
+          github_token: ${{ secrets.MARVIN_TOKEN }}
           claude_args: |
             --allowedTools Bash,Read,Edit,Write,Grep,Glob
           prompt: |
@@ -324,6 +330,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-          # Must be able to read/write issues on $ISSUES_REPO; the default
-          # GITHUB_TOKEN is scoped to this repo and cannot.
+          # Belt-and-braces: the action overrides this in Claude's environment
+          # with the github_token passed above (also MARVIN_TOKEN), but keep it
+          # so gh still authenticates as marvin if that behavior ever changes.
           GH_TOKEN: ${{ secrets.MARVIN_TOKEN }}


### PR DESCRIPTION
## Problem
In [triage run 30309052340](https://github.com/meridianlabs-ai/actions/actions/runs/30309052340) the agent could not comment on the existing tracking issue (meridianlabs-ai/inspect_ai#163): `POST /issues/163/comments` → HTTP 403 **"Resource not accessible by integration"**, and it fell back to dumping its findings into the Slack thread.

That error message is app-installation-token language, not PAT language. `claude-code-action@v1` mints its own GitHub App installation token (via the OIDC exchange) and overrides `GH_TOKEN`/`GITHUB_TOKEN` in the Claude process environment with it — so the step-level `env: GH_TOKEN: ${{ secrets.MARVIN_TOKEN }}` added in #72 never reached `gh`. The app token is read-only on the inspect_ai fork, hence the 403.

## Fix
- Pass `github_token: ${{ secrets.MARVIN_TOKEN }}` to the action. Per the action's token resolution (`OVERRIDE_GITHUB_TOKEN`), this skips the app-token exchange entirely and the PAT is what Claude's `gh` authenticates with. `i-am-marvin` has write on both this repo and the fork (verified via the collaborators API).
- Drop the `id-token: write` permission — it existed only for the now-skipped OIDC exchange.
- Keep the step-level `GH_TOKEN` env as belt-and-braces, with an updated comment.

Verification will be the next scheduled-test failure that matches an existing issue, or a `workflow_dispatch` re-run of triage against a failed run id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)