### PR TITLE
fix: run all trio variants in scheduled tests

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -211,7 +211,7 @@ jobs:
 
         run: |
           echo "Running trio tests with --runslow and --runtrio flags..."
-          pytest --runtrio --runslow --runapi -m "slow or api or trio" --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" --timeout=1500 ${{ inputs.pytest_args }}
+          pytest --runtrio --runslow --runapi --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" --timeout=1500 ${{ inputs.pytest_args }}
 
       - name: Save tested inspect_ai SHA as artifact
         if: success() && github.event_name == 'schedule'


### PR DESCRIPTION
Drops the `-m "slow or api or trio"` filter from the trio leg of the scheduled tests workflow.

The inspect_ai conftest's `--runtrio` flag already restricts the run to `[trio]` variants only (everything else is skipped at collection), so the marker filter was narrowing the leg to only slow/api-marked trio variants. Removing it runs all ~2,471 `[trio]` variants, per meridianlabs-ai/inspect_ai#171.

`--runslow` and `--runapi` are kept so trio variants that also carry those marks aren't gated out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)