### PR TITLE
Wire DeepSeek, Mistral, and Moonshot API keys into scheduled inspect_ai tests

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -188,8 +188,11 @@ jobs:
           BUILDX_CACHE_FROM: type=local,src=/tmp/.buildx-cache
           BUILDX_CACHE_TO: type=local,dest=/tmp/.buildx-cache,mode=max
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
         run: |
@@ -205,8 +208,11 @@ jobs:
           BUILDX_CACHE_FROM: type=local,src=/tmp/.buildx-cache
           BUILDX_CACHE_TO: type=local,dest=/tmp/.buildx-cache,mode=max
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
         run: |


### PR DESCRIPTION
The scheduled inspect_ai test runs (`pytest --runslow --runapi` every 2 hours) only pass Anthropic/Google/Grok/OpenAI keys, so live tests gated on other providers self-skip via `skip_if_no_*` and have never run on the scheduled cadence. That includes the Kimi/Moonshot suite (~29 tests, added with UKGovernmentBEIS/inspect_ai#4540), Mistral's live suite (~31 tests), and the new DeepSeek V4 suite (~16 tests, UKGovernmentBEIS/inspect_ai#4710).

This adds `DEEPSEEK_API_KEY`, `MISTRAL_API_KEY`, and `MOONSHOT_API_KEY` — all now present as repo secrets — to both the slow-tests and trio-tests env blocks.

Cost note: runs skip when upstream `main` hasn't moved, and these providers' tests mostly use small/flash-tier models; the largest single cost is DeepSeek's context-overflow test (~1.28M input tokens ≈ $0.18/run).

Remaining unwired providers with live tests (no secrets available yet): Together (23), Groq (17), Cloudflare (8), OpenRouter (3), Fireworks/SambaNova/Perplexity (3 each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)