### PR TITLE
Restore local main ref in slow-tests checkout to fix sandbox-tools failures

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -179,6 +179,18 @@ jobs:
           ref: ${{ needs.check-commit.outputs.sha }}
           fetch-depth: 0
 
+      # Checking out a pinned SHA leaves a detached HEAD with no local `main`
+      # branch. inspect_ai's sandbox-tools install-state check runs
+      # `git diff main` to detect edits to sandbox-tools code and treats a
+      # failure to resolve `main` as "edited", which resolves a `-dev` helper
+      # binary that doesn't exist in CI (SandboxInjectionError in all
+      # sandbox-tools tests). Recreate `main` at the tested commit's closest
+      # ancestor on origin/main (the commit itself for scheduled runs) so the
+      # check sees exactly the sandbox-tools changes the commit carries
+      # relative to real main.
+      - name: Create local main ref for inspect_ai install-state check
+        run: git branch -f main "$(git merge-base HEAD origin/main)"
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Every scheduled slow-tests run since #77 merged has failed with 14 sandbox-tools/tools-bridge test failures (example: [run 30971333748](https://github.com/meridianlabs-ai/actions/actions/runs/30971333748/job/92196215185)).

**Cause:** #77 changed the slow-tests checkout from the default branch to the pinned SHA resolved by `check-commit`. Checking out a SHA leaves a detached HEAD with no local `main` branch. inspect_ai's sandbox-tools install-state check (`_check_main_divergence` in `src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py`) runs `git diff main` to detect edits to sandbox-tools code and treats failure to resolve `main` (rc 128) the same as real diffs → classifies the checkout "edited" → resolves the `-dev` helper binary, which isn't on S3 and can't be built non-interactively → `SandboxInjectionError` in every test that injects sandbox tools.

**Fix:** after checkout, recreate `main` at the tested commit's closest ancestor on `origin/main` (`git merge-base HEAD origin/main` — the commit itself for scheduled runs, which test origin/main's tip). This keeps #77's SHA pinning while restoring the git state the install-state check expects, and stays correct if a non-main ref is ever tested: the check then sees exactly the sandbox-tools changes that ref carries relative to real main, rather than being forced to "clean".

Verified the mechanism locally in an inspect_ai checkout: `test_text_editor_read_missing` passes on a clean checkout, fails with the identical `SandboxInjectionError` after renaming the local `main` ref away, and passes again with `main` recreated via merge-base.

The underlying fragility is also filed upstream as [inspect_ai#4755](https://github.com/UKGovernmentBEIS/inspect_ai/issues/4755) (the check should distinguish rc 128 from rc 1 and fall back to `origin/main`); this PR unblocks the scheduled runs without waiting on that.

🤖 Opened with [Claude Code](https://claude.com/claude-code)
