### PR TITLE
Run slow tests with pytest-xdist (-n auto)

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -238,7 +238,11 @@ jobs:
 
         run: |
           echo "Running ${{ matrix.mode }} slow tests..."
-          pytest ${{ matrix.pytest_flags }} --runslow --runapi --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" --timeout=${{ matrix.test_timeout }} ${{ inputs.pytest_args }}
+          # -n auto / --timeout-method=thread mirror the main repo's CI test
+          # job (build.yml). The suite is latency-bound (serial provider API
+          # calls and docker container churn), not CPU-bound, so xdist
+          # parallelism cuts wall-clock dramatically.
+          pytest ${{ matrix.pytest_flags }} --runslow --runapi --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" -n auto --timeout=${{ matrix.test_timeout }} --timeout-method=thread ${{ inputs.pytest_args }}
 
       - name: Cleanup Docker resources
         if: always()


### PR DESCRIPTION
Stacked on #79 (base auto-retargets to `main` when it merges).

The slow-tests pytest invocation runs single-process: ~9,300 tests serially, ~73 minutes for the asyncio leg. Per-file timing from [run 30948409497](https://github.com/meridianlabs-ai/actions/actions/runs/30948409497) shows the suite is latency-bound, not CPU-bound — `tests/model` alone is 24 min of serial provider API calls, `tests/tools` 14 min of docker container churn — so the runner's CPUs sit idle most of the run. pytest-xdist is already installed (it's an inspect_ai dev dependency) but never enabled.

This adds `-n auto --timeout-method=thread`, mirroring the main repo's CI test job (`build.yml`: `pytest -rA --doctest-modules --color=yes -n auto --timeout=900 --timeout-method=thread`). `--timeout-method=thread` is required alongside xdist since the signal-based default doesn't work in worker processes.

Expected effect: wall-clock drops toward the longest serial tail rather than the sum of all files. The push trigger runs the workflow on this branch for a live before/after number.

Risk: the main repo runs its (non-slow) suite under xdist routinely, but this is the first time the `--runslow --runapi` set runs parallel — watch the validation run for tests that assume exclusive docker resources, fixed ports, or trip provider rate limits. If a handful of files misbehave, the fallback is marking them for serial execution rather than abandoning parallelism.

🤖 Opened with [Claude Code](https://claude.com/claude-code)
