### PR TITLE
ci: run slow tests on 8-core larger runner

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -240,11 +240,13 @@ jobs:
 
         run: |
           echo "Running ${{ matrix.mode }} slow tests..."
-          # -n auto / --timeout-method=thread mirror the main repo's CI test
-          # job (build.yml). The suite is latency-bound (serial provider API
+          # --timeout-method=thread mirrors the main repo's CI test job
+          # (build.yml). The suite is latency-bound (serial provider API
           # calls and docker container churn), not CPU-bound, so xdist
-          # parallelism cuts wall-clock dramatically.
-          pytest ${{ matrix.pytest_flags }} --runslow --runapi --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" -n auto --timeout=${{ matrix.test_timeout }} --timeout-method=thread ${{ inputs.pytest_args }}
+          # parallelism cuts wall-clock dramatically. -n logical (not auto):
+          # with psutil installed, auto counts physical cores — 4 on this
+          # hyperthreaded 8-vCPU runner — while logical uses all 8.
+          pytest ${{ matrix.pytest_flags }} --runslow --runapi --ignore=tests/agent/test_agent_human.py -k "not test_mcp_sampling_fn" -n logical --timeout=${{ matrix.test_timeout }} --timeout-method=thread ${{ inputs.pytest_args }}
 
       - name: Cleanup Docker resources
         if: always()

--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -147,7 +147,9 @@ jobs:
   slow-tests:
     needs: check-commit
     if: needs.check-commit.outputs.skip_tests != 'true'
-    runs-on: ubuntu-latest
+    # Larger GitHub-hosted runner (8-core / 32 GB / 300 GB SSD); the suite's
+    # -n auto xdist parallelism and docker churn scale with cores.
+    runs-on: slow_test_runner
     timeout-minutes: 180
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Moves the `slow-tests` matrix job in `inspect-ai-scheduled-tests.yml` from `ubuntu-latest` (2-core) to the new **`slow_test_runner`** GitHub-hosted larger runner (8-core / 32 GB RAM / 300 GB SSD).

- **`-n auto` → `-n logical`**: with psutil installed (an inspect_ai dependency), xdist's `auto` counts *physical* cores — 4 on this hyperthreaded 8-vCPU runner. `logical` spawns a worker per vCPU, using all 8.
- Docker-heavy sandbox tests get more RAM and disk headroom (300 GB vs 14 GB SSD on standard runners).
- `check-commit` and `report` stay on `ubuntu-latest` — they're trivial bookkeeping jobs and standard-runner minutes are free, while every larger-runner minute is billed.

## Validation

This workflow triggers on push to all branches, so pushing this branch kicks off a live run of both matrix legs (asyncio + trio) on the new runner. If the job sits in **Queued** and never starts, the runner name in org settings doesn't match `slow_test_runner` exactly — fix the name there or here before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)