### PR TITLE
Pre-install inspect_ai's tests/test_package in scheduled slow tests

### DIFF
--- a/.github/workflows/inspect-ai-scheduled-tests.yml
+++ b/.github/workflows/inspect-ai-scheduled-tests.yml
@@ -222,6 +222,10 @@ jobs:
           # Install inspect_ai with development dependencies for testing
           pip install --only-binary=all -e ".[dev]"
           pip install pytest-timeout
+          # Pre-install the test fixture extension package so inspect_ai's
+          # ensure_test_package_installed() short-circuits instead of
+          # pip-installing it mid-run on the xdist critical path (~9s).
+          pip install --no-deps ./tests/test_package
 
       - name: Run slow tests (${{ matrix.mode }})
         timeout-minutes: 180


### PR DESCRIPTION
inspect_ai's `ensure_test_package_installed()` pip-installs `tests/test_package` mid-run when it isn't importable — a ~9s subprocess paid on the pytest critical path by whichever of its three caller tests runs first (visible as `test_solver_extension` ~9.4s in `--durations` output), plus a lock-wait echo in a second caller. Pre-installing it in the install step makes the helper's `find_spec` check short-circuit.

Same change is landing in inspect_ai's PR-gate workflow: UKGovernmentBEIS/inspect_ai#4760. No coverage change: the entry-point discovery machinery (`clear_entry_points_state`/`ensure_entry_points`) still runs on every helper call; only the pip subprocess is skipped, and inspect_ai's conftest `pytest_sessionfinish` uninstall behavior is unaffected.

Prepared with Claude Code (/ci-perf), human-reviewed before opening.