### PR TITLE
Add nightly Windows fast-unit-test run for inspect_ai

### DIFF
--- a/.github/workflows/inspect-ai-windows-tests.yml
+++ b/.github/workflows/inspect-ai-windows-tests.yml
@@ -65,10 +65,16 @@ jobs:
       # Checking out a pinned SHA/other-repo ref leaves a detached HEAD with
       # no local `main`; some install-state checks in inspect_ai run
       # `git diff main` and treat a failure to resolve it as "edited". Same
-      # workaround as inspect-ai-scheduled-tests.yml.
+      # workaround as inspect-ai-scheduled-tests.yml — but only when HEAD is
+      # actually detached: checking out the default branch puts us ON `main`,
+      # which both makes the ref exist already and makes force-updating it
+      # fatal ("used by worktree").
       - name: Create local main ref for inspect_ai install-state check
         shell: bash
-        run: git branch -f main "$(git merge-base HEAD origin/main)"
+        run: |
+          if [ "$(git rev-parse --abbrev-ref HEAD)" = "HEAD" ]; then
+            git branch -f main "$(git merge-base HEAD origin/main)"
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0

--- a/.github/workflows/inspect-ai-windows-tests.yml
+++ b/.github/workflows/inspect-ai-windows-tests.yml
@@ -1,0 +1,150 @@
+---
+name: Inspect AI Windows Tests
+
+# Nightly run of the inspect_ai fast unit suite on Windows. The main repo's
+# CI (build.yml `test` job) is ubuntu-only, so Windows-specific breakage in
+# pure-Python paths (os.path/os.sep handling, file URIs, sockets, subprocess)
+# is invisible until a user hits it (e.g. UKGovernmentBEIS/inspect_ai#4765).
+# This runs the same pytest invocation as the main repo's fast suite, on
+# windows-latest. Slow/sandbox tests are deliberately out of scope: GitHub's
+# Windows runners cannot run Linux containers.
+
+"on":
+  schedule:
+    # Nightly at 05:30 UTC (~00:30 Boston); offset from the 2-hourly
+    # scheduled slow tests which fire on the hour.
+    - cron: "30 5 * * *"
+  push:
+    branches:
+      - "windows-tests**" # Dev-cycle trigger: push a branch matching this to test workflow changes
+  workflow_dispatch:
+    inputs:
+      inspect_ai_ref:
+        description: "inspect_ai branch/tag/commit to checkout"
+        required: false
+        default: ""
+        type: string
+      pytest_args:
+        description: "Additional arguments to pass to pytest (as a single string)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  UV_VERSION: 0.9.4
+
+jobs:
+  windows-tests:
+    runs-on: windows-latest
+    timeout-minutes: 120
+    outputs:
+      sha: ${{ steps.inspect_commit.outputs.sha }}
+      short_sha: ${{ steps.inspect_commit.outputs.short_sha }}
+      ref: ${{ steps.inspect_commit.outputs.ref }}
+
+    steps:
+      - name: Checkout inspect_ai repository
+        uses: actions/checkout@v6
+        with:
+          repository: UKGovernmentBEIS/inspect_ai
+          ref: ${{ inputs.inspect_ai_ref || '' }}
+          fetch-depth: 0
+          submodules: true
+
+      - name: Get inspect_ai commit info
+        id: inspect_commit
+        shell: bash
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "ref=${{ inputs.inspect_ai_ref || 'main' }}" >> $GITHUB_OUTPUT
+
+      # Checking out a pinned SHA/other-repo ref leaves a detached HEAD with
+      # no local `main`; some install-state checks in inspect_ai run
+      # `git diff main` and treat a failure to resolve it as "edited". Same
+      # workaround as inspect-ai-scheduled-tests.yml.
+      - name: Create local main ref for inspect_ai install-state check
+        shell: bash
+        run: git branch -f main "$(git merge-base HEAD origin/main)"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: "3.11"
+
+      - name: Install dependencies
+        # Mirrors build.yml `test`: tests/test_package is pre-installed so
+        # ensure_test_package_installed() short-circuits mid-run.
+        shell: bash
+        run: |
+          uv venv
+          uv pip install .[dev]
+          uv pip install --no-deps ./tests/test_package
+
+      - name: Run fast unit tests (Windows)
+        # Same invocation as the main repo's build.yml `test` job so this is
+        # a pure OS delta, not a different test selection. --timeout (thread
+        # method) fails hung tests with a traceback instead of hanging to the
+        # job timeout.
+        shell: bash
+        run: uv run pytest -rA --doctest-modules --color=yes -n auto --timeout=900 --timeout-method=thread --durations=50 --durations-min=1 ${{ inputs.pytest_args }}
+
+  report:
+    needs: windows-tests
+    # Slack only for scheduled nightly runs against main; dev-cycle pushes
+    # and manual dispatches report via the Actions UI alone.
+    if: always() && github.event_name == 'schedule' && needs.windows-tests.result != 'cancelled'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report test results to Slack
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "text": "${{ needs.windows-tests.result == 'success' && '✅ Windows Tests Passed' || '🚨 Windows Tests Failed' }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ needs.windows-tests.result == 'success' && '✅ Windows Tests Passed' || '🚨 Windows Tests Failed' }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Trigger:*\n${{ github.event_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tested:*\n<https://github.com/UKGovernmentBEIS/inspect_ai/commit/${{ needs.windows-tests.outputs.sha }}|inspect_ai@${{ needs.windows-tests.outputs.ref }}#${{ needs.windows-tests.outputs.short_sha }}>"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.windows-tests.result != 'success' && 'The nightly Windows unit tests failed. Please investigate.' || 'Windows unit tests completed successfully.' }}"
+                  }
+                }
+              ]
+            }

--- a/INSPECT_AI_TESTS.md
+++ b/INSPECT_AI_TESTS.md
@@ -74,3 +74,21 @@ To modify the workflow:
 2. **Python Version**: Change `python-version` in the setup steps
 3. **Timeout**: Adjust `timeout-minutes` value as needed
 4. **Reporting**: Implement custom notification logic in the "Report test results" step
+
+## Workflow: `inspect-ai-windows-tests.yml`
+
+### Purpose
+
+inspect_ai's own CI (`build.yml`) runs ubuntu-only, so Windows-specific breakage in pure-Python paths (path separators, file URIs, sockets, subprocess) goes undetected (e.g. UKGovernmentBEIS/inspect_ai#4765). This workflow runs the **fast unit suite** — the same pytest invocation as the main repo's `test` job — on `windows-latest`, nightly.
+
+Slow/sandbox tests are deliberately excluded: GitHub's Windows runners cannot run Linux containers.
+
+### Schedule
+
+- **Automatic**: Nightly at 05:30 UTC against inspect_ai `main`
+- **Manual**: `workflow_dispatch` with optional `inspect_ai_ref` and `pytest_args`
+- **Dev cycle**: Pushing a branch named `windows-tests**` to this repo triggers a run
+
+### Reporting
+
+Scheduled runs post pass/fail to Slack (same bot/channel as the scheduled slow tests, without `@channel`). Dispatch and dev-cycle runs report via the Actions UI only.


### PR DESCRIPTION
## Summary

inspect_ai's CI (`build.yml`) is ubuntu-only, so Windows-specific regressions in pure-Python paths (path separators, file URIs, sockets, subprocess) go undetected until a user hits one — e.g. UKGovernmentBEIS/inspect_ai#4765, where Inspect View returned 403 for every local log on Windows.

This adds `inspect-ai-windows-tests.yml`: a nightly (05:30 UTC) run of the **fast unit suite** — the exact same pytest invocation as inspect_ai's `build.yml` `test` job — on `windows-latest` / Python 3.11, so any delta vs upstream CI is a pure OS difference. Slow/sandbox tests are deliberately excluded (Windows runners can't run Linux containers).

- **Triggers:** nightly schedule; `workflow_dispatch` with `inspect_ai_ref` / `pytest_args`; dev-cycle push trigger scoped to `windows-tests**` branches.
- **Reporting:** scheduled runs post to the same Slack channel as the scheduled slow tests, without `@channel` until the job is burned in. Dispatch/dev runs report via the Actions UI only.
- Docs added to `INSPECT_AI_TESTS.md`.

## Status

Draft while we triage the first runs on this branch: failures need sorting into real Windows bugs vs tests needing `skipif` marks (fixes land in inspect_ai). Will mark ready once the run is green or the remaining failures have upstream issues filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)